### PR TITLE
Fix LSTM training shape bug

### DIFF
--- a/ml_model.py
+++ b/ml_model.py
@@ -28,8 +28,10 @@ def train_models(df, feature_columns):
     X_scaled = scaler.fit_transform(X[:-1])
 
     # Train LSTM
-    lstm_model = build_lstm_model((X_scaled.shape[1], X_scaled.shape[1]))
-    lstm_model.fit(X_scaled, y, epochs=50, batch_size=32)
+    # Reshape for LSTM which expects 3D input: (samples, timesteps, features)
+    X_lstm = X_scaled.reshape((X_scaled.shape[0], 1, X_scaled.shape[1]))
+    lstm_model = build_lstm_model((1, X_scaled.shape[1]))
+    lstm_model.fit(X_lstm, y, epochs=50, batch_size=32)
     lstm_model.save(LSTM_MODEL_FILE)
 
     # Train XGBoost
@@ -44,12 +46,13 @@ def predict_next_price(df, feature_columns):
     scaler = joblib.load("scaler.pkl")
     X = df[feature_columns].values[-1:]
     X_scaled = scaler.transform(X)
+    X_lstm = X_scaled.reshape((X_scaled.shape[0], 1, X_scaled.shape[1]))
 
     lstm_model = load_model(LSTM_MODEL_FILE)
     xgb_model = xgb.XGBRegressor()
     xgb_model.load_model(XGB_MODEL_FILE)
 
-    lstm_pred = lstm_model.predict(X_scaled)[0][0]
+    lstm_pred = lstm_model.predict(X_lstm)[0][0]
     xgb_pred = xgb_model.predict(X_scaled)[0]
 
     return (lstm_pred + xgb_pred) / 2


### PR DESCRIPTION
## Summary
- fix shape of training data for LSTM model
- reshape features before training and inference

## Testing
- `python -m py_compile data_utils.py ml_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6879bffc1bc48330be95bf3a2231c2ee